### PR TITLE
WESTPA 2.0: Amber GPU Tutorial Fix

### DIFF
--- a/additional_tutorials/basic_nacl_amber_GPU/node.sh
+++ b/additional_tutorials/basic_nacl_amber_GPU/node.sh
@@ -7,11 +7,14 @@ cd $1; shift
 source env.sh
 export WEST_JOBID=$1; shift
 export SLURM_NODENAME=$1; shift
+export CUDA_VISIBLE_DEVICES_ALLOCATED=$1; shift
 # export LOCAL=/local/$WEST_JOBID
 echo "starting WEST client processes on: "; hostname
 echo "current directory is $PWD"
 echo "environment is: "
 env | sort
+
+echo "CUDA_VISIBLE_DEVICES = " $CUDA_VISIBLE_DEVICES
 
 w_run "$@" &> west-$SLURM_NODENAME-node.log
 

--- a/additional_tutorials/basic_nacl_amber_GPU/runwe_bridges.sh
+++ b/additional_tutorials/basic_nacl_amber_GPU/runwe_bridges.sh
@@ -3,8 +3,8 @@
 #SBATCH --output=slurm.out
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=2
-#SBATCH --cluster=invest
-#SBATCH --partition=lchong
+#SBATCH --cluster=GPU
+#SBATCH --partition=gtx1080
 #SBATCH --gres=gpu:2
 #SBATCH --time=24:00:00
 
@@ -38,8 +38,10 @@ fi
 
 # start clients, with the proper number of cores on each
 
+scontrol show hostname $SLURM_NODELIST >& SLURM_NODELIST.log
+
 for node in $(scontrol show hostname $SLURM_NODELIST); do
-    ssh -o StrictHostKeyChecking=no $node $PWD/node.sh $SLURM_SUBMIT_DIR $SLURM_JOBID $node --work-manager=zmq --zmq-mode=client --zmq-read-host-info=$SERVER_INFO --zmq-comm-mode=tcp &
+    ssh -o StrictHostKeyChecking=no $node $PWD/node.sh $SLURM_SUBMIT_DIR $SLURM_JOBID $node $CUDA_VISIBLE_DEVICES --work-manager=zmq --n-workers=2 --zmq-mode=client --zmq-read-host-info=$SERVER_INFO --zmq-comm-mode=tcp &
 done
 
 

--- a/additional_tutorials/basic_nacl_amber_GPU/westpa_scripts/runseg.sh
+++ b/additional_tutorials/basic_nacl_amber_GPU/westpa_scripts/runseg.sh
@@ -19,7 +19,7 @@ elif [ "$WEST_CURRENT_SEG_INITPOINT_TYPE" = "SEG_INITPOINT_NEWTRAJ" ]; then
   ln -sv $WEST_PARENT_DATA_REF ./parent.rst
 fi
 
-$SANDER -O -i md.in   -p nacl.parm7  -c parent.rst \
+$PMEMD -O -i md.in   -p nacl.parm7  -c parent.rst \
            -r seg.rst -x seg.nc      -o seg.log    -inf seg.nfo
 
 TEMP=$(mktemp)


### PR DESCRIPTION
FIx Amber GPU tutorial so it actually runs on GPUs instead of on CPUs using SANDER (for westpa-2.0-restruct)